### PR TITLE
Datapagev1

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,1 @@
 package-lock=false
-@nandosuk:registry=https://europe-west2-npm.pkg.dev/mgt-build-56d2ff6b/nandos-central-npm/
-//europe-west2-npm.pkg.dev/mgt-build-56d2ff6b/nandos-central-npm/:_password=""
-//europe-west2-npm.pkg.dev/mgt-build-56d2ff6b/nandos-central-npm/:username=oauth2accesstoken
-//europe-west2-npm.pkg.dev/mgt-build-56d2ff6b/nandos-central-npm/:email=not.valid@email.com
-//europe-west2-npm.pkg.dev/mgt-build-56d2ff6b/nandos-central-npm/:always-auth=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,0 @@
-package-lock=false
-@nandosuk:registry=https://europe-west2-npm.pkg.dev/mgt-build-56d2ff6b/nandos-central-npm/
-//europe-west2-npm.pkg.dev/mgt-build-56d2ff6b/nandos-central-npm/:_password=""
-//europe-west2-npm.pkg.dev/mgt-build-56d2ff6b/nandos-central-npm/:username=oauth2accesstoken
-//europe-west2-npm.pkg.dev/mgt-build-56d2ff6b/nandos-central-npm/:email=not.valid@email.com
-//europe-west2-npm.pkg.dev/mgt-build-56d2ff6b/nandos-central-npm/:always-auth=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,6 @@
 package-lock=false
+@nandosuk:registry=https://europe-west2-npm.pkg.dev/mgt-build-56d2ff6b/nandos-central-npm/
+//europe-west2-npm.pkg.dev/mgt-build-56d2ff6b/nandos-central-npm/:_password=""
+//europe-west2-npm.pkg.dev/mgt-build-56d2ff6b/nandos-central-npm/:username=oauth2accesstoken
+//europe-west2-npm.pkg.dev/mgt-build-56d2ff6b/nandos-central-npm/:email=not.valid@email.com
+//europe-west2-npm.pkg.dev/mgt-build-56d2ff6b/nandos-central-npm/:always-auth=true

--- a/gen-nodejs/parquet_types.js
+++ b/gen-nodejs/parquet_types.js
@@ -358,6 +358,7 @@ var DataPageHeader = module.exports.DataPageHeader = function(args) {
   this.definition_level_encoding = null;
   this.repetition_level_encoding = null;
   this.statistics = null;
+  this.is_compressed = true;
   if (args) {
     if (args.num_values !== undefined && args.num_values !== null) {
       this.num_values = args.num_values;
@@ -381,6 +382,9 @@ var DataPageHeader = module.exports.DataPageHeader = function(args) {
     }
     if (args.statistics !== undefined && args.statistics !== null) {
       this.statistics = new ttypes.Statistics(args.statistics);
+    }
+    if (args.is_compressed !== undefined && args.is_compressed !== null) {
+      this.is_compressed = args.is_compressed;
     }
   }
 };

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -311,6 +311,10 @@ function encodeDataPage(column, valueCount, values, rlevels, dlevels) {
         bitWidth: column.typeLength
       });
 
+  let valuesBufCompressed = parquet_compression.deflate(
+      column.compression,
+      valuesBuf);
+
   /* encode repetition and definition levels */
   let rLevelsBuf = Buffer.alloc(0);
   if (column.rLevelMax > 0) {
@@ -331,11 +335,13 @@ function encodeDataPage(column, valueCount, values, rlevels, dlevels) {
   }
 
   /* build page header */
-  let pageBody = Buffer.concat([rLevelsBuf, dLevelsBuf, valuesBuf]);
+
   let pageHeader = new parquet_thrift.PageHeader()
   pageHeader.type = parquet_thrift.PageType['DATA_PAGE'];
-  pageHeader.uncompressed_page_size = pageBody.length;
-  pageHeader.compressed_page_size = pageBody.length;
+  pageHeader.uncompressed_page_size =
+  rLevelsBuf.length + dLevelsBuf.length + valuesBuf.length;
+  pageHeader.compressed_page_size =
+  rLevelsBuf.length + dLevelsBuf.length + valuesBufCompressed.length;
   pageHeader.data_page_header = new parquet_thrift.DataPageHeader();
   pageHeader.data_page_header.num_values = valueCount;
 
@@ -345,8 +351,14 @@ function encodeDataPage(column, valueCount, values, rlevels, dlevels) {
   pageHeader.data_page_header.repetition_level_encoding =
       parquet_thrift.Encoding[PARQUET_RDLVL_ENCODING];
 
+  pageHeader.data_page_header.is_compressed =
+      column.compression !== 'UNCOMPRESSED';
   /* concat page header, repetition and definition levels and values */
-  return Buffer.concat([parquet_util.serializeThrift(pageHeader), pageBody]);
+  return Buffer.concat([
+    parquet_util.serializeThrift(pageHeader),
+    rLevelsBuf,
+    dLevelsBuf,
+    valuesBufCompressed]);
 }
 
 /**
@@ -459,8 +471,7 @@ function encodeColumnChunk(values, opts) {
   metadata.total_compressed_size = pagesBuf.length;
 
   metadata.type = parquet_thrift.Type[opts.column.primitiveType];
-  metadata.codec = parquet_thrift.CompressionCodec[
-      opts.useDataPageV2 ? opts.column.compression : 'UNCOMPRESSED'];
+  metadata.codec = parquet_thrift.CompressionCodec[opts.column.compression];
 
   /* list encodings */
   let encodingsSet = {};

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "parquetjs",
+  "name": "@nandosuk/parquetjs",
   "description": "fully asynchronous, pure JavaScript implementation of the Parquet file format",
   "main": "parquet.js",
   "version": "0.11.2",
-  "homepage": "https://github.com/ironSource/parquetjs",
-  "author": "ironSource <npm@ironsrc.com>",
+  "homepage": "https://github.com/nandosuk/parquetjs",
+  "author": "NandosUK",
   "license": "MIT",
   "keywords": [
     "dremel",
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/ironSource/parquetjs.git"
+    "url": "git://github.com/nandosuk/parquetjs.git"
   },
   "dependencies": {
     "async-mutex": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@nandosuk/parquetjs",
+  "name": "@dni/parquetjs",
   "description": "fully asynchronous, pure JavaScript implementation of the Parquet file format",
   "main": "parquet.js",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "homepage": "https://github.com/nandosuk/parquetjs",
   "author": "NandosUK",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@nandosuk/parquetjs",
   "description": "fully asynchronous, pure JavaScript implementation of the Parquet file format",
   "main": "parquet.js",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "homepage": "https://github.com/nandosuk/parquetjs",
   "author": "NandosUK",
   "license": "MIT",


### PR DESCRIPTION
This PR will allow compression when dataPageV2 is disabled. 

The encodeDataPage function in writer.js has been updated to use compression. 

The DataPageHeader in parquet_types.js has also been updated to have an additional check for compression